### PR TITLE
[Feature] Making TTS API call separate and Audio sampling rate based on connectivity

### DIFF
--- a/lib/common/widgets/asr_tts_actions.dart
+++ b/lib/common/widgets/asr_tts_actions.dart
@@ -25,6 +25,7 @@ class ASRAndTTSActions extends StatelessWidget {
     required String currentDuration,
     required String totalDuration,
     required Function onMusicPlayOrStop,
+    required bool isLoading,
   })  : _isEnabled = isEnabled,
         _textToCopy = textToCopy,
         _audioPathToShare = audioPathToShare,
@@ -33,7 +34,8 @@ class ASRAndTTSActions extends StatelessWidget {
         _isPlayingAudio = isPlayingAudio,
         _currentDuration = currentDuration,
         _totalDuration = totalDuration,
-        _onAudioPlayOrStop = onMusicPlayOrStop;
+        _onAudioPlayOrStop = onMusicPlayOrStop,
+        _isLoading = isLoading;
 
   final bool _isEnabled, _isRecordedAudio, _isPlayingAudio;
   final String _textToCopy;
@@ -42,6 +44,7 @@ class ASRAndTTSActions extends StatelessWidget {
   final PlayerController _playerController;
   final String _currentDuration;
   final String _totalDuration;
+  final bool _isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -152,11 +155,18 @@ class ASRAndTTSActions extends StatelessWidget {
               color: _isEnabled ? flushOrangeColor : goastWhite,
             ),
             padding: AppEdgeInsets.instance.all(8),
-            child: SvgPicture.asset(
-              _isPlayingAudio ? iconStopPlayback : iconSound,
+            child: SizedBox(
               height: 24.toWidth,
               width: 24.toWidth,
-              color: _isEnabled ? balticSea : americanSilver,
+              child: _isLoading
+                  ? CircularProgressIndicator(
+                      color: balticSea,
+                      strokeWidth: 2,
+                    )
+                  : SvgPicture.asset(
+                      _isPlayingAudio ? iconStopPlayback : iconSound,
+                      color: _isEnabled ? balticSea : americanSilver,
+                    ),
             ),
           ),
         ),

--- a/lib/common/widgets/asr_tts_actions.dart
+++ b/lib/common/widgets/asr_tts_actions.dart
@@ -1,4 +1,5 @@
 import 'package:audio_waveforms/audio_waveforms.dart';
+import 'package:bhashaverse/enums/speaker_status.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/svg.dart';
@@ -18,33 +19,29 @@ class ASRAndTTSActions extends StatelessWidget {
     super.key,
     required String textToCopy,
     String? audioPathToShare,
-    required bool isEnabled,
     required PlayerController playerController,
     required bool isRecordedAudio,
-    required bool isPlayingAudio,
     required String currentDuration,
     required String totalDuration,
     required Function onMusicPlayOrStop,
-    required bool isLoading,
-  })  : _isEnabled = isEnabled,
-        _textToCopy = textToCopy,
+    required SpeakerStatus speakerStatus,
+  })  : _textToCopy = textToCopy,
         _audioPathToShare = audioPathToShare,
         _playerController = playerController,
         _isRecordedAudio = isRecordedAudio,
-        _isPlayingAudio = isPlayingAudio,
         _currentDuration = currentDuration,
         _totalDuration = totalDuration,
         _onAudioPlayOrStop = onMusicPlayOrStop,
-        _isLoading = isLoading;
+        _speakerStatus = speakerStatus;
 
-  final bool _isEnabled, _isRecordedAudio, _isPlayingAudio;
+  final bool _isRecordedAudio;
   final String _textToCopy;
   final String? _audioPathToShare;
   final Function _onAudioPlayOrStop;
   final PlayerController _playerController;
   final String _currentDuration;
   final String _totalDuration;
-  final bool _isLoading;
+  final SpeakerStatus _speakerStatus;
 
   @override
   Widget build(BuildContext context) {
@@ -52,7 +49,7 @@ class ASRAndTTSActions extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
         Visibility(
-          visible: !_isPlayingAudio,
+          visible: _speakerStatus != SpeakerStatus.playing,
           child: Row(
             children: [
               InkWell(
@@ -104,7 +101,7 @@ class ASRAndTTSActions extends StatelessWidget {
         ),
         Expanded(
           child: Visibility(
-            visible: _isPlayingAudio,
+            visible: _speakerStatus == SpeakerStatus.playing,
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -143,7 +140,7 @@ class ASRAndTTSActions extends StatelessWidget {
         SizedBox(width: 12.toWidth),
         InkWell(
           onTap: () {
-            if (_isEnabled) {
+            if (_speakerStatus != SpeakerStatus.disabled) {
               _onAudioPlayOrStop();
             } else {
               showDefaultSnackbar(message: cannotPlayAudioAtTheMoment.tr);
@@ -152,20 +149,26 @@ class ASRAndTTSActions extends StatelessWidget {
           child: Container(
             decoration: BoxDecoration(
               shape: BoxShape.circle,
-              color: _isEnabled ? flushOrangeColor : goastWhite,
+              color: _speakerStatus != SpeakerStatus.disabled
+                  ? flushOrangeColor
+                  : goastWhite,
             ),
             padding: AppEdgeInsets.instance.all(8),
             child: SizedBox(
               height: 24.toWidth,
               width: 24.toWidth,
-              child: _isLoading
+              child: _speakerStatus == SpeakerStatus.loading
                   ? CircularProgressIndicator(
                       color: balticSea,
                       strokeWidth: 2,
                     )
                   : SvgPicture.asset(
-                      _isPlayingAudio ? iconStopPlayback : iconSound,
-                      color: _isEnabled ? balticSea : americanSilver,
+                      _speakerStatus == SpeakerStatus.playing
+                          ? iconStopPlayback
+                          : iconSound,
+                      color: _speakerStatus != SpeakerStatus.disabled
+                          ? balticSea
+                          : americanSilver,
                     ),
             ),
           ),

--- a/lib/enums/speaker_status.dart
+++ b/lib/enums/speaker_status.dart
@@ -1,0 +1,6 @@
+enum SpeakerStatus {
+  disabled,
+  loading,
+  stopped,
+  playing,
+}

--- a/lib/presentation/home/bottom_nav_screens/bottom_nav_translation/bottom_nav_translation_screen.dart
+++ b/lib/presentation/home/bottom_nav_screens/bottom_nav_translation/bottom_nav_translation_screen.dart
@@ -152,7 +152,8 @@ class _BottomNavTranslationState extends State<BottomNavTranslation>
                                     isRecordedAudio: !_hiveDBInstance
                                         .get(isStreamingPreferred),
                                     onMusicPlayOrStop: () async {
-                                      if (shouldShowWaveforms(false)) {
+                                      if (isAudioPlaying(
+                                          isForTargetSection: false)) {
                                         await _bottomNavTranslationController
                                             .stopPlayer();
                                       } else if (_bottomNavTranslationController
@@ -227,7 +228,8 @@ class _BottomNavTranslationState extends State<BottomNavTranslation>
                                   isRecordedAudio: !_hiveDBInstance
                                       .get(isStreamingPreferred),
                                   onMusicPlayOrStop: () async {
-                                    if (shouldShowWaveforms(true)) {
+                                    if (isAudioPlaying(
+                                        isForTargetSection: true)) {
                                       await _bottomNavTranslationController
                                           .stopPlayer();
                                     } else {
@@ -723,7 +725,7 @@ class _BottomNavTranslationState extends State<BottomNavTranslation>
     _bottomNavTranslationController.clearTransliterationHints();
   }
 
-  bool shouldShowWaveforms(bool isForTargetSection) {
+  bool isAudioPlaying({required bool isForTargetSection}) {
     return ((isForTargetSection &&
             _bottomNavTranslationController.targetSpeakerStatus.value ==
                 SpeakerStatus.playing) ||

--- a/lib/presentation/home/bottom_nav_screens/bottom_nav_translation/controller/bottom_nav_translation_controller.dart
+++ b/lib/presentation/home/bottom_nav_screens/bottom_nav_translation/controller/bottom_nav_translation_controller.dart
@@ -64,7 +64,7 @@ class BottomNavTranslationController extends GetxController {
   DateTime? recordingStartTime;
   String beepSoundPath = '';
   late File beepSoundFile;
-  PlayerController _controller = PlayerController();
+  PlayerController _playerController = PlayerController();
   late Directory appDirectory;
   Rx<SpeakerStatus> sourceSpeakerStatus = Rx(SpeakerStatus.disabled);
   Rx<SpeakerStatus> targetSpeakerStatus = Rx(SpeakerStatus.disabled);
@@ -726,14 +726,14 @@ class BottomNavTranslationController extends GetxController {
   }
 
   Future<void> playBeepSound() async {
-    if (_controller.playerState == PlayerState.playing ||
-        _controller.playerState == PlayerState.paused) {
-      await _controller.stopPlayer();
+    if (_playerController.playerState == PlayerState.playing ||
+        _playerController.playerState == PlayerState.paused) {
+      await _playerController.stopPlayer();
     }
-    await _controller.preparePlayer(
+    await _playerController.preparePlayer(
       path: beepSoundFile.path,
       shouldExtractWaveform: false,
     );
-    await _controller.startPlayer(finishMode: FinishMode.pause);
+    await _playerController.startPlayer(finishMode: FinishMode.pause);
   }
 }

--- a/lib/presentation/home/bottom_nav_screens/bottom_nav_translation/controller/bottom_nav_translation_controller.dart
+++ b/lib/presentation/home/bottom_nav_screens/bottom_nav_translation/controller/bottom_nav_translation_controller.dart
@@ -688,7 +688,8 @@ class BottomNavTranslationController extends GetxController {
   }
 
   Future<void> stopPlayer() async {
-    if (controller.playerState.isPlaying) {
+    if (controller.playerState.isPlaying ||
+        controller.playerState == PlayerState.paused) {
       await controller.stopPlayer();
     }
     targetSpeakerStatus.value = SpeakerStatus.stopped;

--- a/lib/utils/constants/api_constants.dart
+++ b/lib/utils/constants/api_constants.dart
@@ -67,7 +67,7 @@ class APIConstants {
     required bool isRecorded,
     required String inputData,
     String audioFormat = 'wav',
-    String sampleRate = '44100',
+    int samplingRate = 16000, // default
     String? asrServiceID,
     String? translationServiceID,
   }) {
@@ -80,7 +80,7 @@ class APIConstants {
             "config": {
               "language": {"sourceLanguage": srcLanguage},
               "audioFormat": audioFormat,
-              "samplingRate": sampleRate,
+              "samplingRate": samplingRate,
             }
           },
         {

--- a/lib/utils/constants/api_constants.dart
+++ b/lib/utils/constants/api_constants.dart
@@ -60,7 +60,7 @@ class APIConstants {
   };
 
   // payload for Compute request
-  static Map<String, dynamic> createRESTComputePayload({
+  static Map<String, dynamic> createComputePayloadASRTrans({
     required String srcLanguage,
     required String targetLanguage,
     required String preferredGender,
@@ -70,13 +70,12 @@ class APIConstants {
     String sampleRate = '44100',
     String? asrServiceID,
     String? translationServiceID,
-    String? ttsServiceID,
   }) {
     var computeRequestToSend = {
       "pipelineTasks": [
         if (isRecorded)
           {
-            "serviceId": "",
+            "serviceId": asrServiceID ?? "",
             "taskType": "asr",
             "config": {
               "language": {"sourceLanguage": srcLanguage},
@@ -85,7 +84,7 @@ class APIConstants {
             }
           },
         {
-          "serviceId": "",
+          "serviceId": translationServiceID ?? "",
           "taskType": "translation",
           "config": {
             "language": {
@@ -94,20 +93,39 @@ class APIConstants {
             }
           }
         },
-        {
-          "serviceId": "",
-          "taskType": "tts",
-          "config": {
-            "language": {"sourceLanguage": targetLanguage},
-            "gender": preferredGender
-          }
-        }
       ],
       "inputData": {
         isRecorded ? 'audio' : 'input': [
           {
             isRecorded ? 'audioContent' : 'source': inputData,
           }
+        ]
+      }
+    };
+
+    return computeRequestToSend;
+  }
+
+  static Map<String, dynamic> createComputePayloadTTS({
+    required String srcLanguage,
+    required String preferredGender,
+    required String inputData,
+    String? ttsServiceID,
+  }) {
+    var computeRequestToSend = {
+      "pipelineTasks": [
+        {
+          "serviceId": ttsServiceID ?? "",
+          "taskType": "tts",
+          "config": {
+            "language": {"sourceLanguage": srcLanguage},
+            "gender": preferredGender
+          }
+        }
+      ],
+      "inputData": {
+        'input': [
+          {'source': inputData}
         ]
       }
     };

--- a/lib/utils/voice_recorder.dart
+++ b/lib/utils/voice_recorder.dart
@@ -15,7 +15,7 @@ class VoiceRecorder {
   File? audioWavInputFile;
   String _speechToBase64 = '';
 
-  Future<void> startRecordingVoice() async {
+  Future<void> startRecordingVoice(int samplingRate) async {
     recordingPath = recordedAudioFileName =
         '$defaultAudioRecordingName${DateTime.now().millisecondsSinceEpoch}${Platform.isAndroid ? '.wav' : '.flac'}';
 
@@ -28,6 +28,7 @@ class VoiceRecorder {
 
     await _audioRec.start(
       encoder: Platform.isAndroid ? AudioEncoder.wav : AudioEncoder.flac,
+      samplingRate: samplingRate,
       path: '$recordingPath/$recordedAudioFileName',
     );
   }


### PR DESCRIPTION
- TTS API call only happen if user press speaker icon
- Adding sampling rate as per device connectivity (Mobile or Wifi)
- If user is on Mobile data, then sampling rate would be it's 8000, otherwise it would be 16000
- There will be loading indicator replaced with Speaker icon in TTS API call
- Once user fetch TTS audio output, then it will play automatically and next time same audio play until user request for new translation
- Adding `SpeakerStauts` enum for status of the speaker
- Refactored minor code