### PR TITLE
[Fix] Language name in native instead of app language when search

### DIFF
--- a/lib/presentation/app_language/app_language_screen.dart
+++ b/lib/presentation/app_language/app_language_screen.dart
@@ -34,9 +34,7 @@ class _AppLanguageScreenState extends State<AppLanguageScreen> {
     _appLanguageController = Get.find();
     _languageSearchController = TextEditingController();
     _hiveDBInstance = Hive.box(hiveDBName);
-    if (Get.arguments != null && Get.arguments[selectedLanguage] != null) {
-      setSelectedLanguageFromArg(Get.arguments[selectedLanguage]);
-    }
+    setSelectedLanguageFromArg();
     ScreenUtil().init();
     super.initState();
   }
@@ -230,10 +228,14 @@ class _AppLanguageScreenState extends State<AppLanguageScreen> {
         langCode: selectedLangCode);
   }
 
-  void setSelectedLanguageFromArg(String name) {
-    _appLanguageController.setSelectedLanguageIndex(_appLanguageController
-        .getAppLanguageList()
-        .indexWhere((element) => element[APIConstants.kNativeName] == name));
+  void setSelectedLanguageFromArg() {
+    if (Get.arguments != null && Get.arguments[selectedLanguage] != null) {
+      _appLanguageController.setSelectedLanguageIndex(_appLanguageController
+          .getAppLanguageList()
+          .indexWhere((element) =>
+              element[APIConstants.kNativeName] ==
+              Get.arguments[selectedLanguage]));
+    }
   }
 
   Future<bool> _onWillPop() async {

--- a/lib/presentation/app_language/controller/app_language_controller.dart
+++ b/lib/presentation/app_language/controller/app_language_controller.dart
@@ -9,6 +9,7 @@ class AppLanguageController extends GetxController {
   final RxList<Map<String, dynamic>> _languageList =
       <Map<String, dynamic>>[].obs;
   late final Box _hiveDBInstance;
+  String _selectedLanguageCode = '';
 
   @override
   void onInit() {
@@ -23,11 +24,14 @@ class AppLanguageController extends GetxController {
 
   void setSelectedLanguageIndex(int? index) {
     _selectedLanguageIndex.value = index;
+    if (index != null) {
+      _selectedLanguageCode =
+          getAppLanguageList()[index][APIConstants.kLanguageCode];
+    }
   }
 
   String getSelectedLanguageCode() {
-    return getAppLanguageList()[getSelectedLanguageIndex() ?? 0]
-        [APIConstants.kLanguageCode];
+    return _selectedLanguageCode;
   }
 
   void saveSelectedLocaleInDB() {
@@ -46,6 +50,7 @@ class AppLanguageController extends GetxController {
       _languageList.add(language);
       if (language[APIConstants.kLanguageCode] == Get.locale?.languageCode) {
         setSelectedLanguageIndex(i);
+        _selectedLanguageCode = language[APIConstants.kLanguageCode]!;
       }
     }
   }


### PR DESCRIPTION
- issue with selected language index. When searching, if selected language not in list, then first language becomes selected as null safety issue ( ?? 0). So instead of getting language code from current language index, creating new variable.