### PR TITLE
[Fix] Assamese language code issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ name: bhashaverse
   connectivity_plus: ^3.0.5
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  freezed: ^2.3.2
+  freezed: ^2.3.5
   freezed_annotation: ^2.2.0
-  json_serializable: ^6.5.4
+  json_serializable: ^6.7.1
   flutter_svg: ^1.1.6
   google_fonts: ^4.0.4
   avatar_glow: ^2.0.2
@@ -60,7 +60,7 @@ name: bhashaverse
 
 * Dev Dependencies:
 ```yaml
-  build_runner: ^2.3.3
+  build_runner: ^2.4.6
   flutter_launcher_icons: ^0.11.0
 ```
 

--- a/lib/utils/app_locale_helper.dart
+++ b/lib/utils/app_locale_helper.dart
@@ -45,6 +45,8 @@ setAppLocale(String locale) {
     case sa:
       i18n.LocaleSettings.setLocale(i18n.AppLocale.sa);
       break;
+    // build_runner showed issue while generating with 'as' language code
+    // Hence, using asm instead
     case asm:
       i18n.LocaleSettings.setLocale(i18n.AppLocale.as);
       break;

--- a/lib/utils/app_locale_helper.dart
+++ b/lib/utils/app_locale_helper.dart
@@ -45,7 +45,7 @@ setAppLocale(String locale) {
     case sa:
       i18n.LocaleSettings.setLocale(i18n.AppLocale.sa);
       break;
-    case as:
+    case asm:
       i18n.LocaleSettings.setLocale(i18n.AppLocale.as);
       break;
     case mai:

--- a/lib/utils/constants/language_map_translated.dart
+++ b/lib/utils/constants/language_map_translated.dart
@@ -13,6 +13,8 @@ const String doi = 'doi';
 const String ne = 'ne';
 const String si = 'si';
 const String sa = 'sa';
+// build_runner showed issue while generating with 'as' language code
+// Hence, using asm instead
 const String asm = 'as';
 const String mai = 'mai';
 const String bho = 'bho';

--- a/lib/utils/constants/language_map_translated.dart
+++ b/lib/utils/constants/language_map_translated.dart
@@ -13,7 +13,7 @@ const String doi = 'doi';
 const String ne = 'ne';
 const String si = 'si';
 const String sa = 'sa';
-const String as = 'as';
+const String asm = 'as';
 const String mai = 'mai';
 const String bho = 'bho';
 const String ml = 'ml';
@@ -41,7 +41,7 @@ List<String> languagesCodeList = [
   ne,
   si,
   sa,
-  as,
+  asm,
   mai,
   bho,
   ml,


### PR DESCRIPTION
- `build_runner` showed issue while generating with `as` language code. Hence, using `asm` for Assamese language code
- Also updating `freezed`, `json_serializable` and `build_runner`  packages